### PR TITLE
Fix: Check if is_numeric before casting

### DIFF
--- a/src/Model/LanguageSkillModel.php
+++ b/src/Model/LanguageSkillModel.php
@@ -13,7 +13,7 @@ namespace Eoko\TextKernel\Model;
 class LanguageSkillModel extends XmlModelBase
 {
     /**
-     * @var integer
+     * @var string
      */
     private $languageSkillCode;
     /**
@@ -30,7 +30,7 @@ class LanguageSkillModel extends XmlModelBase
     private $languageProficiencyCodeDescription;
 
     /**
-     * @return int
+     * @return string
      */
     public function getLanguageSkillCode()
     {
@@ -38,7 +38,7 @@ class LanguageSkillModel extends XmlModelBase
     }
 
     /**
-     * @param int $languageSkillCode
+     * @param string $languageSkillCode
      * @return LanguageSkillModel
      */
     public function setLanguageSkillCode($languageSkillCode)

--- a/src/Service/XmlToModel.php
+++ b/src/Service/XmlToModel.php
@@ -103,7 +103,7 @@ class XmlToModel
 
         if (strlen($value) <= 0) {
             return null;
-        } else if (preg_match('/Code$/i', $key)) {
+        } else if (preg_match('/Code$/i', $key) && is_numeric($value)) {
             return (int)$value;
         } else if (preg_match('/Date$/i', $key) || preg_match('/^Date/i', $key)) {
             if (($value = \DateTime::createFromFormat('Y-m-d', $value)) !== false) {


### PR DESCRIPTION
Specific keys like languageSkillCode are parsed as a INT, even though it is supposed to be a string (ISO CODE like "FR", "EN" etc...).

The problem resulting is that every languageSkillCode are casted to int because of the /Code$/i regex, and so the parseElement returns "0" every time.

To avoid this we can check if the value is numeric in addition to the /Code$/i regex.